### PR TITLE
Fixing silent failure in parsing implementation

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -220,6 +220,9 @@ mod tests {
         assert!(parse("a124GB").is_err());
         assert!(parse("1.3 42.0 B").is_err());
         assert!(parse("1.3 ... B").is_err());
+        // The original implementation did not account for the possibility that users may
+        // use whitespace to visually separate digits, thus treat it as an error
+        assert!(parse("1 000 B").is_err());
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -218,6 +218,8 @@ mod tests {
 
         assert!(parse("").is_err());
         assert!(parse("a124GB").is_err());
+        assert!(parse("1.3 42.0 B").is_err());
+        assert!(parse("1.3 ... B").is_err());
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -10,9 +10,7 @@ impl std::str::FromStr for ByteSize {
         let number = take_while(value, |c| c.is_ascii_digit() || c == '.');
         match number.parse::<f64>() {
             Ok(v) => {
-                let suffix = skip_while(value, |c| {
-                    c.is_whitespace() || c.is_ascii_digit() || c == '.'
-                });
+                let suffix = skip_while(&value[number.len()..], char::is_whitespace);
                 match suffix.parse::<Unit>() {
                     Ok(u) => Ok(Self((v * u) as u64)),
                     Err(error) => Err(format!(


### PR DESCRIPTION
Replay of https://github.com/bytesize-rs/bytesize/pull/59

> The way the parse was implemented accepted additional numeric characters
> or `.` after the first valid `f64` literal but ignored them.
> 
> This permitted more strings than are invalid following a strict grammar
> for byte sizes and silently ignores the further symbols without error.
> 
> ```
> 1.0 ...KB
> 1.0 42.0 B
> ```
> This change makes those illegal.
> 
> `1 000 B` was also subject to the bad `skip_while` ignoring the
> following `000`. In this version of the fix whitespace is not accepted
> as a digit separator. So it will raise an error if the user doesn't
> explicitly strip the whitespace instead of reporting a wrong value.
> 
> 